### PR TITLE
Remove AnyObject constraint on rows element type

### DIFF
--- a/FTMTableSectionModules/Classes/Core/TableSectionModule.swift
+++ b/FTMTableSectionModules/Classes/Core/TableSectionModule.swift
@@ -15,7 +15,7 @@ private struct TableSectionModuleConstants{
 }
 
 open class TableSectionModule: NSObject {
-    open var rows:[AnyObject] = []
+    open var rows:[Any] = []
     weak internal var sectionSource: TableSectionModuleSectionSource?
     fileprivate(set) open var tableView:UITableView
     open var section: NSInteger {


### PR DESCRIPTION
### Overview

To permit the use of not reference type like `Struct` the `Element` type of the `rows` must change from `AnyObject` to `Any`