### PR TITLE
fix: add tableview editing callbacks

### DIFF
--- a/Sources/ModuleServices/ModulesViewController.swift
+++ b/Sources/ModuleServices/ModulesViewController.swift
@@ -203,11 +203,6 @@ extension ModulesViewController: UITableViewDelegate, UITableViewDataSource {
         }
     }
     
-    public func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
-                          toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
-        proposedDestinationIndexPath
-    }
-    
     public func tableView(_ tableView: UITableView, indentationLevelForRowAt indexPath: IndexPath) -> Int {
         modules[indexPath.section].tableView(tableView, indentationLevelForRowAtIndexPath: indexPath)
     }
@@ -254,6 +249,17 @@ extension ModulesViewController: UITableViewDelegate, UITableViewDataSource {
     
     public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         modules[indexPath.section].tableView(tableView, canMoveRowAtIndexPath: indexPath)
+    }
+    
+    public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle,
+                          forRowAt indexPath: IndexPath) {
+        modules[indexPath.section].tableView(tableView, commitEditingStyle: editingStyle, forRowAtIndexPath: indexPath)
+    }
+    
+    public func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
+                          toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        return modules[sourceIndexPath.section].tableView(tableView, targetIndexPathForMoveFromRowAt: sourceIndexPath,
+                                                          toProposedIndexPath: proposedDestinationIndexPath)
     }
     
     public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle,

--- a/Sources/ModuleServices/TableSectionModule.swift
+++ b/Sources/ModuleServices/TableSectionModule.swift
@@ -348,4 +348,14 @@ extension TableSectionModule {
     open func tableView(_ tableView: UITableView, moveRowAtIndexPath sourceIndexPath: IndexPath,
                         toIndexPath destinationIndexPath: IndexPath) {}
     
+    @objc
+    open func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath,
+                        to destinationIndexPath: IndexPath) {}
+    
+    @objc
+    open func tableView(_ tableView: UITableView,
+                        targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
+                        toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        return proposedDestinationIndexPath
+    }
 }


### PR DESCRIPTION
Add the two callback:

```
func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath)
    
func tableView(_ tableView: UITableView,
                        targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
                        toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath
```

that were missing