### PR TITLE
Check that section index exist before calling callback methods

### DIFF
--- a/Sources/ModuleServices/ModulesViewController.swift
+++ b/Sources/ModuleServices/ModulesViewController.swift
@@ -99,14 +99,17 @@ extension ModulesViewController: UITableViewDelegate, UITableViewDataSource {
 
     public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell,
                           forRowAt indexPath: IndexPath) {
+        guard modules.count > indexPath.section else { return }
         modules[indexPath.section].tableView(tableView, didEndDisplayingCell: cell, forRowAtIndexPath: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, didEndDisplayingHeaderView view: UIView, forSection section: Int) {
+        guard modules.count > section else { return }
         modules[section].tableView(tableView, didEndDisplayingHeaderView: view, forSection: section)
     }
     
     public func tableView(_ tableView: UITableView, didEndDisplayingFooterView view: UIView, forSection section: Int) {
+        guard modules.count > section else { return }
         modules[section].tableView(tableView, didEndDisplayingFooterView: view, forSection: section)
     }
     


### PR DESCRIPTION
Reloading all the modules in this way

```
createModules()
tableView?.reloadData()
```

cause these lifetime methods to be called on ModulesViewController  also after a section is deleted
```
    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell,
                          forRowAt indexPath: IndexPath) {
        modules[indexPath.section].tableView(tableView, didEndDisplayingCell: cell, forRowAtIndexPath: indexPath)
    }
    public func tableView(_ tableView: UITableView, didEndDisplayingHeaderView view: UIView, forSection section: Int) {
        modules[section].tableView(tableView, didEndDisplayingHeaderView: view, forSection: section)
    }
    public func tableView(_ tableView: UITableView, didEndDisplayingFooterView view: UIView, forSection section: Int) {
        modules[section].tableView(tableView, didEndDisplayingFooterView: view, forSection: section)
    }
```
so `modules[indexPath.section]` could result in index out of bound (edited) 
