### PR TITLE
Feature request: Allow usage of `ModuleGenericServices` in a local package

### DIFF
--- a/Sources/ModuleGenericServices/SingleCell/Nib/SingleNibCellRowsModule.swift
+++ b/Sources/ModuleGenericServices/SingleCell/Nib/SingleNibCellRowsModule.swift
@@ -9,10 +9,10 @@ import UIKit
 import ModuleServices
 
 open class SingleNibCellRowsModule<Cell: ConfigurableCell, RowsDecorator: RowsDecoratorProtocol>: TableSectionModule {
-    open override func registerNibsForCells() -> [AnyClass] {
-        super.registerNibsForCells() + [
-            Cell.classForCoder()
-        ]
+    var cellBundle: Bundle? { nil }
+    
+    open override func registerNibsForCellsWithBundle() -> CellsClassesWithBundle {
+        CellsClassesWithBundle(classes: [Cell.classForCoder()], bundle: cellBundle)
     }
     
     open override func createRows() {

--- a/Sources/ModuleGenericServices/SingleCell/Nib/SingleNibRowBaseModule.swift
+++ b/Sources/ModuleGenericServices/SingleCell/Nib/SingleNibRowBaseModule.swift
@@ -9,9 +9,9 @@ import UIKit
 import ModuleServices
 
 open class SingleNibRowBaseModule<Cell: ConfigurableCell, Decorator: NSObject>: SingleRowBaseModule<Cell, Decorator> {
-    open override func registerNibsForCells() -> [AnyClass] {
-        super.registerNibsForCells() + [
-            Cell.classForCoder()
-        ]
+    var cellBundle: Bundle? { nil }
+    
+    open override func registerNibsForCellsWithBundle() -> CellsClassesWithBundle {
+        CellsClassesWithBundle(classes: [Cell.classForCoder()], bundle: cellBundle)
     }
 }

--- a/Sources/ModuleServices/TableSectionModule.swift
+++ b/Sources/ModuleServices/TableSectionModule.swift
@@ -93,6 +93,16 @@ extension TableSectionModule {
         return []
     }
     
+    @objc
+    open func registerNibsForCellsWithBundle() -> CellsClassesWithBundle {
+        return CellsClassesWithBundle(classes: [], bundle: nil)
+    }
+    
+    @objc
+    open func registerNibsForHeadersFootersWithBundle() -> CellsClassesWithBundle {
+        return CellsClassesWithBundle(classes: [], bundle: nil)
+    }
+    
     fileprivate func autoRegisterClassForCells() {
         registerClassForCells().forEach { currentClass in
             let identifier = String(describing: currentClass)
@@ -108,20 +118,22 @@ extension TableSectionModule {
     }
     
     fileprivate func autoRegisterNibsForCells() {
-        registerNibsForCells().forEach { currentClass in
-            let identifier = String(describing: currentClass)
-            let nib = UINib(nibName: identifier, bundle: nil)
-            tableView.register(nib, forCellReuseIdentifier: identifier)
-        }
-    }
-    
-    fileprivate func autoRegisterNibsForHeadersFooters() {
-        registerNibsForHeadersFooters().forEach { currentClass in
-            let identifier = String(describing: currentClass)
-            let nib = UINib(nibName: identifier, bundle: nil)
-            tableView.register(nib, forHeaderFooterViewReuseIdentifier: identifier)
-        }
-    }
+          let classesAndBundle = registerNibsForCellsWithBundle()
+          (classesAndBundle.classes + registerNibsForCells()).forEach { currentClass in
+              let identifier = String(describing: currentClass)
+              let nib = UINib(nibName: identifier, bundle: classesAndBundle.bundle)
+              tableView.register(nib, forCellReuseIdentifier: identifier)
+          }
+      }
+      
+      fileprivate func autoRegisterNibsForHeadersFooters() {
+          let classesAndBundle = registerNibsForHeadersFootersWithBundle()
+          (classesAndBundle.classes + registerNibsForHeadersFooters()).forEach { currentClass in
+              let identifier = String(describing: currentClass)
+              let nib = UINib(nibName: identifier, bundle: classesAndBundle.bundle)
+              tableView.register(nib, forHeaderFooterViewReuseIdentifier: identifier)
+          }
+      }
 }
 
 // MARK: - Methods for sepatartor of the Cells
@@ -355,5 +367,15 @@ extension TableSectionModule {
                         targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
                         toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         return proposedDestinationIndexPath
+    }
+}
+
+open class CellsClassesWithBundle: NSObject {
+    let classes: [AnyClass]
+    let bundle: Bundle?
+
+    public init(classes: [AnyClass], bundle: Bundle?){
+        self.classes = classes
+        self.bundle = bundle
     }
 }


### PR DESCRIPTION
Hey Truji, que pasa? :D 

here is an improvement of the library to allow us to use in a separate package.

# Problem

There is an issue with `ModuleServices` when used with the following setup:

- Main app that use `ModuleServices`
- Local package that use `ModuleServices` and `ModuleGenericServices`
- Custom module created in the local package and imported in the main app

The issue arise with the auto Nib registration that we have for example here:

```
open class SingleClassCellRowsModule<Cell: ConfigurableCell, RowsDecorator: RowsDecoratorProtocol>: TableSectionModule {
    open override func registerNibsForCells() -> [AnyClass] {
        super.registerNibsForCells() + [
            Cell.classForCoder()
        ]
    }
```

This class override `registerNibsForCells` returning the class name of the cell associated.
The superclass use these class names to register the associated nib file

```
    fileprivate func autoRegisterNibsForCells() {
        registerNibsForCells().forEach { currentClass in
            let identifier = String(describing: currentClass)
            let nib = UINib(nibName: identifier, bundle: nil)
            tableView.register(nib, forCellReuseIdentifier: identifier)
        }
    }
```

The issue is with the bundle parameter, since there is hardcoded as `nil`.
Since the cell nib is defined in a separate package the bundle should be `Bundle.module`, otherwise the app will crash with the exception:

`Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value`

an example repo with the issue could be found [here](https://github.com/Sync-Money/GenericModulesCrash_showcase)

# Proposed Solution

In order to maintain backward compatibility and don't expose the methods `autoRegisterNibsForCells` and `autoRegisterNibsForHeadersFooters` we propose to add two additional methods:

```
    @objc
    open func registerNibsForCellsWithBundle() -> CellsClassesWithBundle {
        return CellsClassesWithBundle(classes: [], bundle: nil)
    }
    
    @objc
    open func registerNibsForHeadersFootersWithBundle() -> CellsClassesWithBundle {
        return CellsClassesWithBundle(classes: [], bundle: nil)
    }
```

so we can slightly change the implementation of `SingleNibRowBaseModule` for example

```
open class SingleNibRowBaseModule<Cell: ConfigurableCell, Decorator: NSObject>: SingleRowBaseModule<Cell, Decorator> {
    var cellBundle: Bundle? { nil }
    
    open override func registerNibsForCellsWithBundle() -> CellsClassesWithBundle {
        CellsClassesWithBundle(classes: [Cell.classForCoder()], bundle: cellBundle)
    }

```
Now if that module is used in a local package we can override the `cellBundle` var using the correct Bundle,.Ex:

```
public class DummyModule: ConfigurableSingleClassRowModule<DummyModuleCell, DummyModuleDecorator> { 
   override var cellBundle: Bundle? { Bundle.module }
}
```
 while we don't need to change that var if we are in the main app.

What do you think of this approach? Do you have other idea?

Thanks,
Iacopo