### PR TITLE
Upgrade to swift5.5 and drop ObjC support

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -12,16 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Github Actions' machines do in fact have recent versions of Xcode,
-    # but you may have to explicitly switch to them.  We explicitly want
-    # to use Xcode 12, so we use xcode-select to switch to it.
-    - name: Switch to Xcode 12.4
-      run: sudo xcode-select --switch /Applications/Xcode_12.4.app
-
-    - name: Generate project file to execute test and build properly
-      run: |
-        swift package generate-xcodeproj
-
     - name: Run tests
       run: |
         xcodebuild test -scheme ModuleServices-Package -destination 'name=iPhone 11'

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,18 @@
-# OS X
-.DS_Store
-
 # Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
+DerivedData/
+*.moved-aside
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -11,26 +21,70 @@ build/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-/.build
-/Packages
-/*.xcodeproj
-xcuserdata/
-*.xccheckout
-profile
-*.moved-aside
-DerivedData
+
+## Obj-C/Swift specific
 *.hmap
+
+## App packaging
 *.ipa
+*.dSYM.zip
+*.dSYM
 
-# Bundler
-.bundle
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
 
-Carthage
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
-# Note: if you ignore the Pods directory, make sure to uncomment
-# `pod install` in .travis.yml
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 # Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/ModuleServices.podspec
+++ b/ModuleServices.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/fjtrujy'
 
   s.ios.deployment_target = '9.0'
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
-  s.swift_version = '5.0'
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.5' }
+  s.swift_version = '5.5'
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|

--- a/ModuleServices.podspec
+++ b/ModuleServices.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "ModuleServices"
-  s.version          = "1.0.3"
+  s.version          = "1.1.0"
   s.summary          = "Reusable ViewController with TableView, splitted in Sections"
 
   s.description      = "Reusable ViewController with TableView, split in Sections (called here modules) that help you to develop faster in Swift"
@@ -35,8 +35,9 @@ Pod::Spec.new do |s|
 
   s.subspec 'Snapshot' do |ss|
     ss.dependency 'ModuleServices/Core'
-    ss.dependency 'CombinationGenerator', '~> 0.2.3'
+    ss.dependency 'CombinationGenerator', '~> 0.2.4'
     ss.source_files = 'Sources/ModuleSnapshotServices/**/*'
+    ss.frameworks = 'XCTest'
   end
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class FirstSectionModule: TableSectionModule {
     }
     
     override func registerClassForCells() -> [AnyClass] {
-        return super.registerClassForCells() + [UITableViewCell.classForCoder()]
+        super.registerClassForCells() + [UITableViewCell.classForCoder()]
     }
     
     override func createRows() {

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## Requirements
 
-Is valid for iOS 9 and higher.
-Requires Swift 5.2 and XCode 11.0 or higher.
+Is valid for iOS 12 and higher.
+Requires Swift 5.5 and XCode 11.0 or higher.
 
 ## Installation
 

--- a/Sources/ModuleGenericServices/SingleCell/Class/SelectableSingleClassRowModule.swift
+++ b/Sources/ModuleGenericServices/SingleCell/Class/SelectableSingleClassRowModule.swift
@@ -20,7 +20,7 @@ open class SelectableSingleClassRowModule<Cell: ConfigurableCell, Decorator: Row
 }
 
 // MARK: - SelectableSingleClassRowModuleDelegate
-public protocol SelectableSingleClassRowModuleDelegate: class {
+public protocol SelectableSingleClassRowModuleDelegate: AnyObject {
     func selectableSingleClassRowModule<Cell: ConfigurableCell, Decorator: RowSelectableProtocol>
             (_ module: SelectableSingleClassRowModule<Cell, Decorator>, didSelectElement element: Any)
 }

--- a/Sources/ModuleGenericServices/SingleCell/Nib/SelectableSingleNibRowModule.swift
+++ b/Sources/ModuleGenericServices/SingleCell/Nib/SelectableSingleNibRowModule.swift
@@ -20,7 +20,7 @@ open class SelectableSingleNibRowModule<Cell: ConfigurableCell, Decorator: RowSe
 }
 
 // MARK: - SelectableSingleNibRowModuleDelegate
-public protocol SelectableSingleNibRowModuleDelegate: class {
+public protocol SelectableSingleNibRowModuleDelegate: AnyObject {
     func selectableSingleNibRowModule<Cell: ConfigurableCell, Decorator: RowSelectableProtocol>
             (_ module: SelectableSingleNibRowModule<Cell, Decorator>, didSelectElement element: Any)
 }

--- a/Sources/ModuleServices/ModulesViewController.swift
+++ b/Sources/ModuleServices/ModulesViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 open class ModulesViewController: UIViewController {
     @IBOutlet weak open var tableView:UITableView?
-    fileprivate(set) internal var modules:[TableSectionModule] = []
+    private(set) internal var modules:[TableSectionModule] = []
     
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,18 +41,18 @@ extension ModulesViewController: TableSectionModuleSectionSource {
     }
     
     public func removeAllModules() { modules.removeAll() }
-    public func removeModule(_ module: TableSectionModule) { modules.removeAll{$0.isEqual(module)} }
+    public func removeModule(_ module: TableSectionModule) { modules.removeAll { $0 == module } }
     public func removeModuleAtIndex(_ atIndex: Int) { modules.remove(at: atIndex) }
     public func removeFirstModule() { modules.removeFirst() }
     public func removeLastModule() { modules.removeLast() }
     
-    public func replaceModuleAtSection(_ section: NSInteger, withModule module: TableSectionModule) {
+    public func replaceModuleAtSection(_ section: Int, withModule module: TableSectionModule) {
         module.sectionSource = self
         modules[section] = module
     }
     
-    public func sectionForModule(_ module: TableSectionModule) -> NSInteger {
-        modules.firstIndex(of: module) ?? NSNotFound
+    public func sectionForModule(_ module: TableSectionModule) -> Int? {
+        modules.firstIndex(of: module)
     }
     
     public func firstModule<T: TableSectionModule>() -> T? { modules.first { $0 is T } as? T }
@@ -177,18 +177,15 @@ extension ModulesViewController: UITableViewDelegate, UITableViewDataSource {
         modules[indexPath.section].tableView(tableView, didDeselectRowAtIndexPath: indexPath)
     }
     
-    public func tableView(_ tableView: UITableView,
-                          editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+    public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         modules[indexPath.section].tableView(tableView, editingStyleForRowAtIndexPath: indexPath)
     }
     
-    public func tableView(_ tableView: UITableView,
-                          titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+    public func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
         modules[indexPath.section].tableView(tableView, titleForDeleteConfirmationButtonForRowAtIndexPath: indexPath)
     }
     
-    public func tableView(_ tableView: UITableView,
-                          editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         modules[indexPath.section].tableView(tableView, editActionsForRowAtIndexPath: indexPath)
     }
     
@@ -201,9 +198,8 @@ extension ModulesViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     public func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
-        if let validIndexPath = indexPath, validIndexPath.section < modules.count {
-            modules[validIndexPath.section].tableView(tableView, didEndEditingRowAtIndexPath: validIndexPath)
-        }
+        guard let validIndexPath = indexPath, validIndexPath.section < modules.count else { return }
+        modules[validIndexPath.section].tableView(tableView, didEndEditingRowAtIndexPath: validIndexPath)
     }
     
     public func tableView(_ tableView: UITableView, indentationLevelForRowAt indexPath: IndexPath) -> Int {
@@ -254,20 +250,17 @@ extension ModulesViewController: UITableViewDelegate, UITableViewDataSource {
         modules[indexPath.section].tableView(tableView, canMoveRowAtIndexPath: indexPath)
     }
     
-    public func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath,
-                          to destinationIndexPath: IndexPath) {
-        return modules[sourceIndexPath.section].tableView(tableView, moveRowAt: sourceIndexPath,
-                                                          to: destinationIndexPath)
+    public func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        modules[sourceIndexPath.section].tableView(tableView, moveRowAt: sourceIndexPath, to: destinationIndexPath)
    }
     
-    public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle,
-                          forRowAt indexPath: IndexPath) {
+    public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         modules[indexPath.section].tableView(tableView, commitEditingStyle: editingStyle, forRowAtIndexPath: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
                           toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
-        return modules[sourceIndexPath.section].tableView(tableView, targetIndexPathForMoveFromRowAt: sourceIndexPath,
-                                                          toProposedIndexPath: proposedDestinationIndexPath)
+        modules[sourceIndexPath.section].tableView(tableView, targetIndexPathForMoveFromRowAt: sourceIndexPath,
+                                                   toProposedIndexPath: proposedDestinationIndexPath)
     }
 }

--- a/Sources/ModuleServices/TableSectionModule.swift
+++ b/Sources/ModuleServices/TableSectionModule.swift
@@ -156,14 +156,14 @@ open class TableSectionModule: NSObject {
     }
     
     // MARK: - Methods for sepatartor of the Cells
-    func setupSeparatorInsetForCell(_ cell : UITableViewCell, forIndexPath indexPath : IndexPath) {
+    open func setupSeparatorInsetForCell(_ cell : UITableViewCell, forIndexPath indexPath : IndexPath) {
         // Remove seperator inset
         cell.separatorInset = .zero
         cell.preservesSuperviewLayoutMargins = false
         cell.layoutMargins = .zero
     }
     
-    func removeSeparatorInsetForCell(_ cell : UITableViewCell, forIndexPath indexPath : IndexPath) {
+    open func removeSeparatorInsetForCell(_ cell : UITableViewCell, forIndexPath indexPath : IndexPath) {
         // Remove seperator inset
         cell.separatorInset = UIEdgeInsets.init(top: .zero, left: cell.bounds.size.width, bottom: .zero, right: .zero)
         cell.preservesSuperviewLayoutMargins = true
@@ -171,7 +171,7 @@ open class TableSectionModule: NSObject {
     }
     
     // MARK: - Mothod for Refresh the section
-    func refreshSection() {
+    open func refreshSection() {
         createRows()
         tableView.reloadSections(IndexSet(integer: section), with: .automatic)
     }

--- a/Tests/ModuleServicesTests/ModulesViewControllerTest.swift
+++ b/Tests/ModuleServicesTests/ModulesViewControllerTest.swift
@@ -57,7 +57,7 @@ class ModulesViewControllerTest: XCTestCase {
         
         modulesVC.removeModuleAtIndex(0)
         
-        XCTAssert(modulesVC.sectionForModule(firstModule) == NSNotFound, "The firstModule shouldbn't in the modules array")
+        XCTAssertNil(modulesVC.sectionForModule(firstModule), "The firstModule shouldbn't in the modules array")
         XCTAssert(modulesVC.numberOfSections(in: newTableView) == 1, "The number of section shoulb be 1")
     }
     
@@ -69,7 +69,7 @@ class ModulesViewControllerTest: XCTestCase {
         
         modulesVC.removeFirstModule()
         
-        XCTAssert(modulesVC.sectionForModule(firstModule) == NSNotFound, "The firstModule shouldbn't in the modules array")
+        XCTAssertNil(modulesVC.sectionForModule(firstModule), "The firstModule shouldbn't in the modules array")
         XCTAssert(modulesVC.numberOfSections(in: newTableView) == 1, "The number of section shoulb be 1")
     }
     
@@ -81,7 +81,7 @@ class ModulesViewControllerTest: XCTestCase {
         
         modulesVC.removeLastModule()
         
-        XCTAssert(modulesVC.sectionForModule(lastModule) == NSNotFound, "The firstModule shouldbn't in the modules array")
+        XCTAssertNil(modulesVC.sectionForModule(lastModule), "The firstModule shouldbn't in the modules array")
         XCTAssert(modulesVC.numberOfSections(in: newTableView) == 1, "The number of section shoulb be 1")
     }
     
@@ -103,10 +103,10 @@ class ModulesViewControllerTest: XCTestCase {
         modulesVC.appendModule(secondModule)
         modulesVC.appendModule(lastModule)
         
-        let index = modulesVC.sectionForModule(secondModule)
+        guard let index = modulesVC.sectionForModule(secondModule) else { return XCTFail("There should be module") }
         
         modulesVC.replaceModuleAtSection(index, withModule: newSecondModule)
-        XCTAssert(modulesVC.sectionForModule(secondModule) == NSNotFound, "The second shouldbn't in the modules array")
+        XCTAssertNil(modulesVC.sectionForModule(secondModule), "The second shouldbn't in the modules array")
         XCTAssert(modulesVC.sectionForModule(newSecondModule) == index, "The newSecondModule should be in the second position")
         XCTAssert(modulesVC.numberOfSections(in: newTableView) == 3, "The number of section shoulb be 3")
     }


### PR DESCRIPTION
## Description

This PR basically increases the version of Swift to 5.5 updating it to the new features it brings.
Additionally, other minor changes and improvements have been done,

⚠️ Breaking Change:
- Everything related to `section` was before an `NSInteger`, now it is an `Int`. Ideally, this could be transparent for the majority of projects, however, previously when we were trying to find the index of a concrete module, if it didn't exist, it was returning `NSNotFound`, now it returns `nil`. There were some UnitTests actually checking for `NSNotFound` I have needed to replace them to `nil`